### PR TITLE
Favorite Pictures - Show all images that the user liked 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1588,6 +1588,27 @@ PODS:
     - React-logger (= 0.77.0)
     - React-perflogger (= 0.77.0)
     - React-utils (= 0.77.0)
+  - RNCAsyncStorage (2.1.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNGestureHandler (2.22.1):
     - DoubleConversion
     - glog
@@ -1814,6 +1835,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -1959,6 +1981,8 @@ EXTERNAL SOURCES:
     :path: build/generated/ios
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
@@ -2036,6 +2060,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 3d947e9d62f351c06c71497e1be897e6006dc303
   ReactCodegen: 1baa534318b19e95fb0f02db0a1ae1e3c271944d
   ReactCommon: 6014af4276bb2debc350e2620ef1bd856b4d981c
+  RNCAsyncStorage: 1d119293b08fc8673e775b6f86482a4d9092cc65
   RNGestureHandler: 22ab0e79b8ed145c4bd4a4f85088f5d711f13580
   RNReanimated: ef80cf675203a39bb5e5464234cb08a0f0040ac2
   RNScreens: c8c0b69f667891d474ad1229054d514f06778772

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
     "test": "jest"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.1.1",
     "@react-navigation/elements": "^2.2.5",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.2.0",
     "@shopify/react-native-skia": "^1.11.3",
     "@tanstack/react-query": "^5.65.1",
+    "jotai": "^2.11.3",
     "react": "18.3.1",
     "react-native": "0.77.0",
     "react-native-gesture-handler": "^2.22.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,13 +7,15 @@
 
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
-import React from 'react';
+import React, {useEffect} from 'react';
 import HomeScreen from './screens/HomeScreen';
 import GalleryScreen from './screens/GalleryScreen';
 import LikesScreen from './screens/LikesScreen';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {RootStackParamList} from './types/types';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
+import {Provider, useSetAtom} from 'jotai';
+import {loadFavoritesAtom} from './store/store';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const queryClient = new QueryClient();
@@ -38,14 +40,22 @@ function RootStack() {
 }
 
 function App(): React.JSX.Element {
+  const loadFavorites = useSetAtom(loadFavoritesAtom);
+
+  useEffect(() => {
+    loadFavorites(); // Load stored favorites on app start
+  }, []);
+
   return (
-    <SafeAreaProvider>
-      <SafeAreaView style={{flex: 1}}>
-        <NavigationContainer>
-          <RootStack />
-        </NavigationContainer>
-      </SafeAreaView>
-    </SafeAreaProvider>
+    <Provider>
+      <SafeAreaProvider>
+        <SafeAreaView style={{flex: 1}}>
+          <NavigationContainer>
+            <RootStack />
+          </NavigationContainer>
+        </SafeAreaView>
+      </SafeAreaProvider>
+    </Provider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import React, {useEffect} from 'react';
 import HomeScreen from './screens/HomeScreen';
 import GalleryScreen from './screens/GalleryScreen';
-import LikesScreen from './screens/LikesScreen';
+import FavoritesScreen from './screens/FavoritesScreen';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {RootStackParamList} from './types/types';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
@@ -33,7 +33,7 @@ function RootStack() {
           // Requires swipe down gesture to navigate back like in Snapchat.
           // options={{headerShown: false}}
         />
-        <Stack.Screen name="Likes" component={LikesScreen} />
+        <Stack.Screen name="Favorites" component={FavoritesScreen} />
       </Stack.Navigator>
     </QueryClientProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {RootStackParamList} from './types/types';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
 import {Provider, useSetAtom} from 'jotai';
-import {loadFavoritesAtom} from './store/store';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const queryClient = new QueryClient();
@@ -40,12 +39,6 @@ function RootStack() {
 }
 
 function App(): React.JSX.Element {
-  const loadFavorites = useSetAtom(loadFavoritesAtom);
-
-  useEffect(() => {
-    loadFavorites(); // Load stored favorites on app start
-  }, []);
-
   return (
     <Provider>
       <SafeAreaProvider>

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -10,7 +10,10 @@ type FavoriteButtonProps = {
 
 const FavoriteButton: React.FC<FavoriteButtonProps> = ({picture}) => {
   const [favorites, toggleFavorite] = useAtom(toggleFavoritePictureAtom);
-  const isFavorited = favorites.some(fav => fav.id === picture.id);
+  // TODO - Verify that jotai makes check on the data type entered in favorites
+  // for now I only check for null, as I want to know if the data is not null
+  const isFavorited =
+    favorites === null ? false : favorites.some(fav => fav.id === picture.id);
 
   return (
     <View style={styles.container}>
@@ -26,7 +29,8 @@ const FavoriteButton: React.FC<FavoriteButtonProps> = ({picture}) => {
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    bottom: 20,
+    bottom: 0,
+    height: 120,
     left: '50%',
     transform: [{translateX: -25}],
   },

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {TouchableOpacity, Text, StyleSheet, View} from 'react-native';
+import {useAtom} from 'jotai';
+import {favoritePicturesAtom, toggleFavoritePictureAtom} from '../store/store';
+import {Media} from '../types/types';
+
+type FavoriteButtonProps = {
+  picture: Media;
+};
+
+const FavoriteButton: React.FC<FavoriteButtonProps> = ({picture}) => {
+  const [favorites, toggleFavorite] = useAtom(toggleFavoritePictureAtom);
+  const isFavorited = favorites.some(fav => fav.id === picture.id);
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => toggleFavorite(picture)}>
+        <Text style={styles.icon}>{isFavorited ? '❤️' : '🤍'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 20,
+    left: '50%',
+    transform: [{translateX: -25}],
+  },
+  button: {
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 25,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icon: {
+    fontSize: 24,
+    color: 'white',
+  },
+});
+
+export default FavoriteButton;

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -1,19 +1,31 @@
 import React from 'react';
 import {TouchableOpacity, Text, StyleSheet, View} from 'react-native';
 import {useAtom} from 'jotai';
-import {favoritePicturesAtom, toggleFavoritePictureAtom} from '../store/store';
 import {Media} from '../types/types';
+import {favoritesAtom} from '../store/store';
 
 type FavoriteButtonProps = {
   picture: Media;
 };
 
 const FavoriteButton: React.FC<FavoriteButtonProps> = ({picture}) => {
-  const [favorites, toggleFavorite] = useAtom(toggleFavoritePictureAtom);
+  const [favorites, setFavorites] = useAtom(favoritesAtom);
   // TODO - Verify that jotai makes check on the data type entered in favorites
   // for now I only check for null, as I want to know if the data is not null
   const isFavorited =
     favorites === null ? false : favorites.some(fav => fav.id === picture.id);
+
+  const toggleFavorite = (picture: Media) => {
+    if (isFavorited) {
+      console.log('remove from favorites');
+      setFavorites(favorites.filter(fav => fav.id !== picture.id));
+      console.log('TESTING ' + 'favorites: ', favorites);
+    } else {
+      console.log('add to favorites');
+      setFavorites([...favorites, picture]);
+      console.log('TESTING ' + 'favorites: ', favorites);
+    }
+  };
 
   return (
     <View style={styles.container}>

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -1,0 +1,75 @@
+import {
+  FlatList,
+  View,
+  Dimensions,
+  StyleSheet,
+  ListRenderItem,
+  ViewToken,
+} from 'react-native';
+import {GestureHandlerRootView} from 'react-native-gesture-handler';
+import {useSharedValue} from 'react-native-reanimated';
+import {ImageViewerProps, Media} from '../types/types';
+import PositionIndicator from '../components/PositionIndicator';
+import PinchableImage from '../components/PinchableImage';
+
+// Replace this with the useWindowDimensions() hook
+const {width, height} = Dimensions.get('window');
+
+type ViewableItemsType = {
+  viewableItems: Array<ViewToken<Media>>;
+};
+
+function ImageViewer(props: ImageViewerProps) {
+  const scrollX = useSharedValue(0);
+  const currentIndex = useSharedValue(0);
+  const numberOfImages = props.numberOfImages;
+  const media: Media[] = props.media;
+
+  const renderItem: ListRenderItem<Media> = ({item}) => (
+    <View style={{width, height}}>
+      <PinchableImage item={item} />
+    </View>
+  );
+
+  const onViewableItemsChanged = (props: ViewableItemsType) => {
+    const {viewableItems} = props;
+    if (viewableItems.length > 0) {
+      currentIndex.value = viewableItems[0].index ?? 0;
+    }
+  };
+
+  const viewabilityConfig = {
+    viewAreaCoveragePercentThreshold: 50, // 50% of an image should be visible
+  };
+
+  return (
+    <GestureHandlerRootView style={styles.container}>
+      <FlatList
+        data={media}
+        keyExtractor={item => item.id.toString()}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onViewableItemsChanged={onViewableItemsChanged}
+        viewabilityConfig={viewabilityConfig}
+        renderItem={renderItem}
+        onScroll={event => {
+          scrollX.value = event.nativeEvent.contentOffset.x;
+        }}
+      />
+      <PositionIndicator
+        currentIndex={currentIndex}
+        numberOfImages={numberOfImages}
+      />
+    </GestureHandlerRootView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'black',
+  },
+});
+
+export default ImageViewer;

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -26,7 +26,7 @@ function ImageViewer(props: ImageViewerProps) {
   const media: Media[] = props.media;
 
   const renderItem: ListRenderItem<Media> = ({item}) => (
-    <View style={{width, height}}>
+    <View style={[{width, height}, styles.imageContainer]}>
       <PinchableImage item={item} />
       <FavoriteButton picture={item} />
     </View>
@@ -70,6 +70,12 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: 'black',
+  },
+  imageContainer: {
+    flex: 1,
+    position: 'relative',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -11,8 +11,8 @@ import {useSharedValue} from 'react-native-reanimated';
 import {ImageViewerProps, Media} from '../types/types';
 import PositionIndicator from '../components/PositionIndicator';
 import PinchableImage from '../components/PinchableImage';
+import FavoriteButton from '../components/FavoriteButton'; // Import Favorite Button
 
-// Replace this with the useWindowDimensions() hook
 const {width, height} = Dimensions.get('window');
 
 type ViewableItemsType = {
@@ -28,6 +28,7 @@ function ImageViewer(props: ImageViewerProps) {
   const renderItem: ListRenderItem<Media> = ({item}) => (
     <View style={{width, height}}>
       <PinchableImage item={item} />
+      <FavoriteButton picture={item} />
     </View>
   );
 

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -20,10 +20,10 @@ type ViewableItemsType = {
 };
 
 function ImageViewer(props: ImageViewerProps) {
-  const scrollX = useSharedValue(0);
-  const currentIndex = useSharedValue(0);
   const numberOfImages = props.numberOfImages;
   const media: Media[] = props.media;
+  const scrollX = useSharedValue(0);
+  const currentIndex = useSharedValue(0);
 
   const renderItem: ListRenderItem<Media> = ({item}) => (
     <View style={[{width, height}, styles.imageContainer]}>

--- a/src/components/PinchableImage.tsx
+++ b/src/components/PinchableImage.tsx
@@ -1,0 +1,117 @@
+import {StyleSheet, useWindowDimensions} from 'react-native';
+import {Gesture, GestureDetector} from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  withTiming,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+import {PinchableImageProps} from '../types/types';
+
+function PinchableImage({item}: PinchableImageProps) {
+  const {width, height} = useWindowDimensions();
+  const {portrait} = item.src;
+  const scale = useSharedValue(1);
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const lastScale = useSharedValue(1); // To track previous zoom state
+
+  // **Double-Tap Gesture for Zoom**
+  const doubleTapGesture = Gesture.Tap()
+    .numberOfTaps(2) // Detect double-tap
+    .onEnd(() => {
+      if (scale.value === 1) {
+        // Zoom in
+        scale.value = withTiming(2, {duration: 300});
+        lastScale.value = 2;
+      } else {
+        // Zoom out
+        scale.value = withTiming(1, {duration: 300});
+        translateX.value = withTiming(0, {duration: 300});
+        translateY.value = withTiming(0, {duration: 300});
+        lastScale.value = 1;
+      }
+    });
+
+  // **Pinch Gesture for Manual Zooming**
+  const pinchGesture = Gesture.Pinch()
+    .onUpdate(event => {
+      scale.value = Math.max(1, Math.min(event.scale, 3)); // Min 1x, Max 3x zoom
+    })
+    .onEnd(() => {
+      // Snap back if zoom < 1
+      if (scale.value < 1) {
+        scale.value = withTiming(1, {duration: 300});
+        translateX.value = withTiming(0, {duration: 300});
+        translateY.value = withTiming(0, {duration: 300});
+      }
+    });
+
+  // Pan Gesture (Move)
+  const panGesture = Gesture.Pan()
+    // Use manual activation so we can decide when to activate/fail
+    .manualActivation(true)
+    .onTouchesMove((event, stateManager) => {
+      /*
+        If only one finger is touching AND scale is 1 (i.e., not zoomed),
+        we fail the pan gesture so the FlatList can handle horizontal paging.
+        If scale > 1 or multiple fingers, we activate the pan gesture.
+      */
+      if (event.allTouches.length === 1 && scale.value === 1) {
+        stateManager.fail();
+      } else {
+        stateManager.activate();
+      }
+    })
+    .onUpdate(event => {
+      // Only update translations if we're zoomed in
+      if (scale.value > 1) {
+        translateX.value = event.translationX;
+        translateY.value = event.translationY;
+      }
+    })
+    .onEnd(() => {
+      // Reset if not zoomed in
+      if (scale.value <= 1) {
+        translateX.value = withTiming(0);
+        translateY.value = withTiming(0);
+      }
+    });
+
+  // **Combine Gestures (Pinch, Pan, and Double Tap)**
+  const combinedGesture = Gesture.Simultaneous(
+    pinchGesture,
+    panGesture,
+    doubleTapGesture,
+  );
+
+  // Animated styling
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      transform: [
+        {translateX: translateX.value},
+        {translateY: translateY.value},
+        {scale: scale.value},
+      ],
+    };
+  });
+
+  const styles = {
+    image: {
+      width,
+      height,
+    },
+  };
+
+  return (
+    <GestureDetector gesture={combinedGesture}>
+      <Animated.Image
+        source={{uri: portrait}}
+        style={[styles.image, animatedStyle]}
+        resizeMode="cover"
+        onError={() => console.log(`Failed to load image: ${portrait}`)}
+      />
+    </GestureDetector>
+  );
+}
+
+export default PinchableImage;

--- a/src/components/PinchableImage.tsx
+++ b/src/components/PinchableImage.tsx
@@ -1,4 +1,4 @@
-import {StyleSheet, useWindowDimensions} from 'react-native';
+import {useWindowDimensions} from 'react-native';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,

--- a/src/screens/FavoriteScreen.tsx
+++ b/src/screens/FavoriteScreen.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {View, Text, FlatList, Image, StyleSheet} from 'react-native';
+import {useAtom} from 'jotai';
+import {favoritePicturesAtom} from '../store/store';
+
+const FavoriteScreen = () => {
+  const [favorites] = useAtom(favoritePicturesAtom);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Favorite Images</Text>
+
+      {favorites.length === 0 ? (
+        <Text style={styles.emptyText}>No favorites yet.</Text>
+      ) : (
+        <FlatList
+          data={favorites}
+          keyExtractor={item => item.id.toString()}
+          numColumns={2} // Show images in 2 columns
+          renderItem={({item}) => (
+            <View style={styles.imageContainer}>
+              <Image source={{uri: item.url}} style={styles.image} />
+            </View>
+          )}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#fff',
+    textAlign: 'center',
+    marginBottom: 10,
+  },
+  emptyText: {
+    color: '#aaa',
+    fontSize: 18,
+    textAlign: 'center',
+    marginTop: 20,
+  },
+  imageContainer: {
+    flex: 1,
+    margin: 5,
+    borderRadius: 10,
+    overflow: 'hidden',
+  },
+  image: {
+    width: '100%',
+    height: 150,
+    resizeMode: 'cover',
+    borderRadius: 10,
+  },
+});
+
+export default FavoriteScreen;

--- a/src/screens/FavoritesScreen.tsx
+++ b/src/screens/FavoritesScreen.tsx
@@ -5,6 +5,8 @@ import {favoritePicturesAtom} from '../store/store';
 
 const FavoritesScreen = () => {
   const [favorites] = useAtom(favoritePicturesAtom);
+  console.log('Favorites in FavoriteScreen:', favorites);
+  console.log('Favorites length:', favorites.length);
 
   return (
     <View style={styles.container}>
@@ -16,10 +18,9 @@ const FavoritesScreen = () => {
         <FlatList
           data={favorites}
           keyExtractor={item => item.id.toString()}
-          numColumns={2} // Show images in 2 columns
           renderItem={({item}) => (
             <View style={styles.imageContainer}>
-              <Image source={{uri: item.url}} style={styles.image} />
+              <Image source={{uri: item.src.portrait}} style={styles.image} />
             </View>
           )}
         />

--- a/src/screens/FavoritesScreen.tsx
+++ b/src/screens/FavoritesScreen.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import {View, Text, FlatList, Image, StyleSheet} from 'react-native';
 import {useAtom} from 'jotai';
-import {favoritePicturesAtom} from '../store/store';
+import {favoritesAtom} from '../store/store';
 
 const FavoritesScreen = () => {
-  const [favorites] = useAtom(favoritePicturesAtom);
-  console.log('Favorites in FavoriteScreen:', favorites);
-  console.log('Favorites length:', favorites.length);
+  const [favorites] = useAtom(favoritesAtom);
+  console.log('TESTING ' + 'favorites: ', favorites);
 
   return (
     <View style={styles.container}>

--- a/src/screens/FavoritesScreen.tsx
+++ b/src/screens/FavoritesScreen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {View, Text, FlatList, Image, StyleSheet} from 'react-native';
 import {useAtom} from 'jotai';
 import {favoritesAtom} from '../store/store';
+import ImageViewer from '../components/ImageViewer';
 
 const FavoritesScreen = () => {
   const [favorites] = useAtom(favoritesAtom);
@@ -14,15 +15,7 @@ const FavoritesScreen = () => {
       {favorites.length === 0 ? (
         <Text style={styles.emptyText}>No favorites yet.</Text>
       ) : (
-        <FlatList
-          data={favorites}
-          keyExtractor={item => item.id.toString()}
-          renderItem={({item}) => (
-            <View style={styles.imageContainer}>
-              <Image source={{uri: item.src.portrait}} style={styles.image} />
-            </View>
-          )}
-        />
+        <ImageViewer numberOfImages={favorites.length} media={favorites} />
       )}
     </View>
   );

--- a/src/screens/FavoritesScreen.tsx
+++ b/src/screens/FavoritesScreen.tsx
@@ -3,7 +3,7 @@ import {View, Text, FlatList, Image, StyleSheet} from 'react-native';
 import {useAtom} from 'jotai';
 import {favoritePicturesAtom} from '../store/store';
 
-const FavoriteScreen = () => {
+const FavoritesScreen = () => {
   const [favorites] = useAtom(favoritePicturesAtom);
 
   return (
@@ -61,4 +61,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default FavoriteScreen;
+export default FavoritesScreen;

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -1,26 +1,37 @@
+import {
   FlatList,
   View,
+  Dimensions,
   StyleSheet,
   ListRenderItem,
   ActivityIndicator,
   Text,
   ViewToken,
-  useWindowDimensions,
 } from 'react-native';
-import {GestureHandlerRootView} from 'react-native-gesture-handler';
-import {useSharedValue} from 'react-native-reanimated';
-import {Media, Props} from '../types/types';
+import {
+  GestureHandlerRootView,
+  Gesture,
+  GestureDetector,
+} from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated';
+import {Media, PinchableImageProps, Props} from '../types/types';
 import {useQuery} from '@tanstack/react-query';
 import {getCollectionsMedia} from '../api/api';
 import PositionIndicator from '../components/PositionIndicator';
 import PinchableImage from '../components/PinchableImage';
+
+// Replace this with the useWindowDimensions() hook
+const {width, height} = Dimensions.get('window');
 
 type ViewableItemsType = {
   viewableItems: Array<ViewToken<Media>>;
 };
 
 function GalleryScreen({route}: Props) {
-  const {width, height} = useWindowDimensions();
   const PEXELS_API_KEY = process.env.PEXELS_API_KEY ?? '';
   if (!PEXELS_API_KEY || PEXELS_API_KEY === '') {
     console.warn('PEXELS_API_KEY environment variable is not defined');

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -8,17 +8,9 @@ import {
   Text,
   ViewToken,
 } from 'react-native';
-import {
-  GestureHandlerRootView,
-  Gesture,
-  GestureDetector,
-} from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-} from 'react-native-reanimated';
-import {Media, PinchableImageProps, Props} from '../types/types';
+import {GestureHandlerRootView} from 'react-native-gesture-handler';
+import {useSharedValue} from 'react-native-reanimated';
+import {Media, Props} from '../types/types';
 import {useQuery} from '@tanstack/react-query';
 import {getCollectionsMedia} from '../api/api';
 import PositionIndicator from '../components/PositionIndicator';

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -1,36 +1,17 @@
-import {
-  FlatList,
-  View,
-  Dimensions,
-  StyleSheet,
-  ListRenderItem,
-  ActivityIndicator,
-  Text,
-  ViewToken,
-} from 'react-native';
-import {GestureHandlerRootView} from 'react-native-gesture-handler';
-import {useSharedValue} from 'react-native-reanimated';
+import {View, Dimensions, ActivityIndicator, Text} from 'react-native';
 import {Media, Props} from '../types/types';
 import {useQuery} from '@tanstack/react-query';
 import {getCollectionsMedia} from '../api/api';
-import PositionIndicator from '../components/PositionIndicator';
-import PinchableImage from '../components/PinchableImage';
+import ImageViewer from '../components/ImageViewer';
 
 // Replace this with the useWindowDimensions() hook
-const {width, height} = Dimensions.get('window');
-
-type ViewableItemsType = {
-  viewableItems: Array<ViewToken<Media>>;
-};
+Dimensions.get('window');
 
 function GalleryScreen({route}: Props) {
   const PEXELS_API_KEY = process.env.PEXELS_API_KEY ?? '';
   if (!PEXELS_API_KEY || PEXELS_API_KEY === '') {
     console.warn('PEXELS_API_KEY environment variable is not defined');
   }
-
-  const scrollX = useSharedValue(0);
-  const currentIndex = useSharedValue(0);
 
   // Give a default to prevent crashes
   // const { item = { id: '', name: '' } } = route.params || {};
@@ -54,54 +35,10 @@ function GalleryScreen({route}: Props) {
     );
   }
 
-  const renderItem: ListRenderItem<Media> = ({item}) => (
-    <View style={{width, height}}>
-      <PinchableImage item={item} />
-    </View>
-  );
-
   const numberOfImages = data?.total_results ?? 0;
   const media: Media[] = data?.media || [];
 
-  const onViewableItemsChanged = (props: ViewableItemsType) => {
-    const {viewableItems} = props;
-    if (viewableItems.length > 0) {
-      currentIndex.value = viewableItems[0].index ?? 0;
-    }
-  };
-
-  const viewabilityConfig = {
-    viewAreaCoveragePercentThreshold: 50, // 50% of an image should be visible
-  };
-
-  return (
-    <GestureHandlerRootView style={styles.container}>
-      <FlatList
-        data={media}
-        keyExtractor={item => item.id.toString()}
-        horizontal
-        pagingEnabled
-        showsHorizontalScrollIndicator={false}
-        onViewableItemsChanged={onViewableItemsChanged}
-        viewabilityConfig={viewabilityConfig}
-        renderItem={renderItem}
-        onScroll={event => {
-          scrollX.value = event.nativeEvent.contentOffset.x;
-        }}
-      />
-      <PositionIndicator
-        currentIndex={currentIndex}
-        numberOfImages={numberOfImages}
-      />
-    </GestureHandlerRootView>
-  );
+  return <ImageViewer media={media} numberOfImages={numberOfImages} />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: 'black',
-  },
-});
 
 export default GalleryScreen;

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -1,36 +1,26 @@
-import {
   FlatList,
   View,
-  Dimensions,
   StyleSheet,
   ListRenderItem,
   ActivityIndicator,
   Text,
   ViewToken,
+  useWindowDimensions,
 } from 'react-native';
-import {
-  GestureHandlerRootView,
-  Gesture,
-  GestureDetector,
-} from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-} from 'react-native-reanimated';
-import {Media, PinchableImageProps, Props} from '../types/types';
+import {GestureHandlerRootView} from 'react-native-gesture-handler';
+import {useSharedValue} from 'react-native-reanimated';
+import {Media, Props} from '../types/types';
 import {useQuery} from '@tanstack/react-query';
 import {getCollectionsMedia} from '../api/api';
 import PositionIndicator from '../components/PositionIndicator';
-
-// Replace this with the useWindowDimensions() hook
-const {width, height} = Dimensions.get('window');
+import PinchableImage from '../components/PinchableImage';
 
 type ViewableItemsType = {
   viewableItems: Array<ViewToken<Media>>;
 };
 
-export default function GalleryScreen({route}: Props) {
+function GalleryScreen({route}: Props) {
+  const {width, height} = useWindowDimensions();
   const PEXELS_API_KEY = process.env.PEXELS_API_KEY ?? '';
   if (!PEXELS_API_KEY || PEXELS_API_KEY === '') {
     console.warn('PEXELS_API_KEY environment variable is not defined');
@@ -104,112 +94,11 @@ export default function GalleryScreen({route}: Props) {
   );
 }
 
-function PinchableImage({item}: PinchableImageProps) {
-  const {portrait} = item.src;
-  const scale = useSharedValue(1);
-  const translateX = useSharedValue(0);
-  const translateY = useSharedValue(0);
-  const lastScale = useSharedValue(1); // To track previous zoom state
-
-  // **Double-Tap Gesture for Zoom**
-  const doubleTapGesture = Gesture.Tap()
-    .numberOfTaps(2) // Detect double-tap
-    .onEnd(() => {
-      if (scale.value === 1) {
-        // Zoom in
-        scale.value = withTiming(2, {duration: 300});
-        lastScale.value = 2;
-      } else {
-        // Zoom out
-        scale.value = withTiming(1, {duration: 300});
-        translateX.value = withTiming(0, {duration: 300});
-        translateY.value = withTiming(0, {duration: 300});
-        lastScale.value = 1;
-      }
-    });
-
-  // **Pinch Gesture for Manual Zooming**
-  const pinchGesture = Gesture.Pinch()
-    .onUpdate(event => {
-      scale.value = Math.max(1, Math.min(event.scale, 3)); // Min 1x, Max 3x zoom
-    })
-    .onEnd(() => {
-      // Snap back if zoom < 1
-      if (scale.value < 1) {
-        scale.value = withTiming(1, {duration: 300});
-        translateX.value = withTiming(0, {duration: 300});
-        translateY.value = withTiming(0, {duration: 300});
-      }
-    });
-
-  // Pan Gesture (Move)
-  const panGesture = Gesture.Pan()
-    // Use manual activation so we can decide when to activate/fail
-    .manualActivation(true)
-    .onTouchesMove((event, stateManager) => {
-      /*
-        If only one finger is touching AND scale is 1 (i.e., not zoomed),
-        we fail the pan gesture so the FlatList can handle horizontal paging.
-        If scale > 1 or multiple fingers, we activate the pan gesture.
-      */
-      if (event.allTouches.length === 1 && scale.value === 1) {
-        stateManager.fail();
-      } else {
-        stateManager.activate();
-      }
-    })
-    .onUpdate(event => {
-      // Only update translations if we're zoomed in
-      if (scale.value > 1) {
-        translateX.value = event.translationX;
-        translateY.value = event.translationY;
-      }
-    })
-    .onEnd(() => {
-      // Reset if not zoomed in
-      if (scale.value <= 1) {
-        translateX.value = withTiming(0);
-        translateY.value = withTiming(0);
-      }
-    });
-
-  // **Combine Gestures (Pinch, Pan, and Double Tap)**
-  const combinedGesture = Gesture.Simultaneous(
-    pinchGesture,
-    panGesture,
-    doubleTapGesture,
-  );
-
-  // Animated styling
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      transform: [
-        {translateX: translateX.value},
-        {translateY: translateY.value},
-        {scale: scale.value},
-      ],
-    };
-  });
-
-  return (
-    <GestureDetector gesture={combinedGesture}>
-      <Animated.Image
-        source={{uri: portrait}}
-        style={[styles.image, animatedStyle]}
-        resizeMode="cover"
-        onError={() => console.log(`Failed to load image: ${portrait}`)}
-      />
-    </GestureDetector>
-  );
-}
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: 'black',
   },
-  image: {
-    width, // fill the entire screen width
-    height, // fill the entire screen height
-  },
 });
+
+export default GalleryScreen;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -90,6 +90,14 @@ function HomeScreen() {
     return <ErrorMessage onRetry={refetch} />;
   }
 
+  const FavoriteItem: Collection = {
+    title: 'Favorite Pictures',
+    media_count: 0,
+    id: 0,
+  };
+
+  const collectionsWithFavorites = [FavoriteItem, ...collections];
+
   const renderItem: ListRenderItem<Collection> = ({item}) => (
     <CollectionItem item={item} />
   );
@@ -97,8 +105,8 @@ function HomeScreen() {
   return (
     <FlatList
       testID="collection-list"
-      data={collections}
-      keyExtractor={item => item.id.toString()}
+      data={collectionsWithFavorites}
+      keyExtractor={item => (item.id + 1).toString()}
       renderItem={renderItem}
       onEndReached={loadMore}
       onEndReachedThreshold={0.5}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -16,7 +16,12 @@ import {useNavigation} from '@react-navigation/native';
 
 const CollectionItem: React.FC<CollectionItemProps> = ({item}) => {
   const navigation = useNavigation<NavigationProp>();
-  const onPress = () => navigation.navigate('Gallery', {item});
+  let onPress: () => void;
+  if (item.id === 0) {
+    onPress = () => navigation.navigate('Favorites');
+  } else {
+    onPress = () => navigation.navigate('Gallery', {item});
+  }
   return (
     <TouchableOpacity onPress={onPress} style={styles.collectionItem}>
       <Text>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,42 @@
+import {atom} from 'jotai';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {Media} from '../types/types';
+
+// Atom for storing favorite pictures
+export const favoritePicturesAtom = atom<Media[]>([]);
+
+// Load persisted state from AsyncStorage
+export const loadFavoritesAtom = atom(null, async (get, set) => {
+  try {
+    const storedFavorites = await AsyncStorage.getItem('favorite_pictures');
+    console.log('Stored favorites:', storedFavorites);
+    if (storedFavorites) {
+      set(favoritePicturesAtom, JSON.parse(storedFavorites));
+    }
+  } catch (error) {
+    console.error('Failed to load favorites', error);
+  }
+});
+
+// Atom to toggle favorite pictures and persist changes
+export const toggleFavoritePictureAtom = atom(
+  null,
+  async (get, set, picture: string) => {
+    const currentFavorites = get(favoritePicturesAtom);
+    const updatedFavorites = currentFavorites.includes(picture)
+      ? currentFavorites.filter(fav => fav !== picture)
+      : [...currentFavorites, picture];
+
+    set(favoritePicturesAtom, updatedFavorites);
+
+    // Persist the updated state
+    try {
+      await AsyncStorage.setItem(
+        'favorite_pictures',
+        JSON.stringify(updatedFavorites),
+      );
+    } catch (error) {
+      console.error('Failed to save favorites', error);
+    }
+  },
+);

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,42 +1,17 @@
-import {atom} from 'jotai';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {Media} from '../types/types';
+import {atomWithStorage} from 'jotai/utils';
 
 // Atom for storing favorite pictures
-export const favoritePicturesAtom = atom<Media[]>([]);
-
-// Load persisted state from AsyncStorage
-export const loadFavoritesAtom = atom(null, async (get, set) => {
-  try {
-    const storedFavorites = await AsyncStorage.getItem('favorite_pictures');
-    console.log('Stored favorites:', storedFavorites);
-    if (storedFavorites) {
-      set(favoritePicturesAtom, JSON.parse(storedFavorites));
-    }
-  } catch (error) {
-    console.error('Failed to load favorites', error);
-  }
-});
-
-// Atom to toggle favorite pictures and persist changes
-export const toggleFavoritePictureAtom = atom(
-  null,
-  async (get, set, picture: string) => {
-    const currentFavorites = get(favoritePicturesAtom);
-    const updatedFavorites = currentFavorites.includes(picture)
-      ? currentFavorites.filter(fav => fav !== picture)
-      : [...currentFavorites, picture];
-
-    set(favoritePicturesAtom, updatedFavorites);
-
-    // Persist the updated state
-    try {
-      await AsyncStorage.setItem(
-        'favorite_pictures',
-        JSON.stringify(updatedFavorites),
-      );
-    } catch (error) {
-      console.error('Failed to save favorites', error);
-    }
+export const favoritesAtom = atomWithStorage<Media[]>('favorites', [], {
+  getItem: async key => {
+    const storedFavorites = await AsyncStorage.getItem(key);
+    return storedFavorites ? JSON.parse(storedFavorites) : [];
   },
-);
+  setItem: async (key, newValue) => {
+    await AsyncStorage.setItem(key, JSON.stringify(newValue));
+  },
+  removeItem: async key => {
+    await AsyncStorage.removeItem(key);
+  },
+});

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -23,6 +23,11 @@ export interface MediaAPIResponse {
   total_results: number;
 }
 
+export type ImageViewerProps = {
+  media: Media[];
+  numberOfImages: number;
+};
+
 export type Media = {
   id: number;
   src: {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -42,7 +42,7 @@ export type PinchableImageProps = {
 export type RootStackParamList = {
   Home: undefined;
   Gallery: {item: Collection};
-  Likes: undefined;
+  Favorites: undefined;
 };
 
 export type GalleryScreenProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1993,6 +1993,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-async-storage/async-storage@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@react-native-async-storage/async-storage@npm:2.1.1"
+  dependencies:
+    merge-options: "npm:^3.0.4"
+  peerDependencies:
+    react-native: ^0.0.0-0 || >=0.65 <1.0
+  checksum: 16858168576f034945f1180c9fdb57c54f1de1c80d08054f5d15f43347ac5e85b08f2af31fe632d673e9c09d65b8035bb3c77b61ba1d0dcd0f59240de4ae2ef5
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-clean@npm:15.0.1":
   version: 15.0.1
   resolution: "@react-native-community/cli-clean@npm:15.0.1"
@@ -2999,6 +3010,7 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.3"
     "@babel/runtime": "npm:^7.25.0"
+    "@react-native-async-storage/async-storage": "npm:^2.1.1"
     "@react-native-community/cli": "npm:15.0.1"
     "@react-native-community/cli-platform-android": "npm:15.0.1"
     "@react-native-community/cli-platform-ios": "npm:15.0.1"
@@ -3022,6 +3034,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.2.3"
     jest: "npm:^29.7.0"
     jest-fetch-mock: "npm:^3.0.3"
+    jotai: "npm:^2.11.3"
     prettier: "npm:2.8.8"
     react: "npm:18.3.1"
     react-native: "npm:0.77.0"
@@ -5903,6 +5916,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-obj@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "is-plain-obj@npm:2.1.0"
+  checksum: e5c9814cdaa627a9ad0a0964ded0e0491bfd9ace405c49a5d63c88b30a162f1512c069d5b80997893c4d0181eadc3fed02b4ab4b81059aba5620bfcdfdeb9c53
+  languageName: node
+  linkType: hard
+
 "is-plain-object@npm:^2.0.4":
   version: 2.0.4
   resolution: "is-plain-object@npm:2.0.4"
@@ -6608,6 +6628,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jotai@npm:^2.11.3":
+  version: 2.11.3
+  resolution: "jotai@npm:2.11.3"
+  peerDependencies:
+    "@types/react": ">=17.0.0"
+    react: ">=17.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+  checksum: 0d5f585fdbedaabf7b46c7622a3627fc9011ced28f722a606b324271ad688586f0c8d7c3ba694150bbd90398c4b394b1d75f9ab2c7326cd0d4830027b31bd3fe
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -7017,6 +7052,15 @@ __metadata:
   version: 5.2.1
   resolution: "memoize-one@npm:5.2.1"
   checksum: fd22dbe9a978a2b4f30d6a491fc02fb90792432ad0dab840dc96c1734d2bd7c9cdeb6a26130ec60507eb43230559523615873168bcbe8fafab221c30b11d54c1
+  languageName: node
+  linkType: hard
+
+"merge-options@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "merge-options@npm:3.0.4"
+  dependencies:
+    is-plain-obj: "npm:^2.1.0"
+  checksum: 02b5891ceef09b0b497b5a0154c37a71784e68ed71b14748f6fd4258ffd3fe4ecd5cb0fd6f7cae3954fd11e7686c5cb64486daffa63c2793bbe8b614b61c7055
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Functionalities

The third screen will show all images that the user liked

- [x] The like page should be accessible from the home screen
- [x] It should re-use the image viewer experience, but this time show only the liked pictures
- [x] Unliking a picture should remove the picture from the liked pictures
- [x] The like state should be persisted

Pressing the like button will add the image to the favorites page (here you need to use some kind of state management. The like state should be persisted). The like button should also be built with RN Skia and feature some animation when toggling it.

### Tasks: 

- [x] Create a Favorite button in the HomeScreen to access the FavoriteScreen
- [x] Create a FavoriteScreen which re-uses the ImageViewer Component from GalleryScreen
- [x] Configure Jotai State Management to save favorite pictures in storage
- [x] Create a favorite button in GalleryScreen to save favorite pictures in Jotai store
- [x] Unliking the page removes the picture from FavoriteScreen 