### PR TITLE
refactor: refine favorites tuple type

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -5,6 +5,7 @@ import {
 import {AnimatedProp, PathDef} from '@shopify/react-native-skia';
 import {StyleProp, ViewStyle, ViewToken} from 'react-native';
 import {SharedValue} from 'react-native-reanimated';
+import {Dispatch, SetStateAction} from 'react';
 
 // A common interface for paginated API responses.
 export interface PaginatedResponse {
@@ -124,7 +125,7 @@ export type ViewableItemsType = {
 export type MaybeArray<T> = ArrayLike<T> | null | undefined;
 
 // Type for favorites (Consider refining the updater function's type).
-export type FavoritesType = [Awaited<Media[]>, (args: any) => any];
+export type FavoritesType = [Media[], Dispatch<SetStateAction<Media[]>>];
 
 // Function type for FlatList's getItemLayout.
 export type GetItemLayoutFunction = (


### PR DESCRIPTION
## Summary
- use React's `Dispatch`/`SetStateAction` for `FavoritesType`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/react-native-image-gallery/node_modules/.bin/jest')*
- `yarn lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_68b05fbfb6e48320ad07c9788270c8da