### PR TITLE
fix: ensure favorites list scrolls correctly on Android

### DIFF
--- a/src/screens/FavoritesScreen.tsx
+++ b/src/screens/FavoritesScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import {Text, StyleSheet, View, Platform, FlatList} from 'react-native';
 import {useAtom} from 'jotai';
 import {favoritesAtom} from '../store/store';
@@ -15,11 +15,17 @@ const FavoritesScreen: React.FC = () => {
    * Last item deleted in horizontal flatlist does not adjust scroll position. #27504
    * https://github.com/facebook/react-native/issues/27504
    */
-  const onEndReachedCallback = useCallback(() => {
-    if (imageViewerRef?.current && isPlatformAndroid) {
-      imageViewerRef.current.scrollToEnd();
+  const prevFavoritesLength = useRef(favorites.length);
+
+  useEffect(() => {
+    if (
+      isPlatformAndroid &&
+      favorites.length < prevFavoritesLength.current
+    ) {
+      imageViewerRef.current?.scrollToEnd();
     }
-  }, [isPlatformAndroid]);
+    prevFavoritesLength.current = favorites.length;
+  }, [favorites.length, isPlatformAndroid]);
 
   return (
     <>
@@ -32,7 +38,6 @@ const FavoritesScreen: React.FC = () => {
           ref={imageViewerRef}
           numberOfImages={favorites.length}
           media={favorites}
-          onEndReachedCallback={onEndReachedCallback}
         />
       )}
     </>


### PR DESCRIPTION
## Summary
- remove `onEndReachedCallback` from `FavoritesScreen`'s `ImageViewer`
- auto-scroll to end when favorites shrink on Android using `useEffect`

## Testing
- `npm test` *(fails: Cannot find module '.../node_modules/.bin/jest')*
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org)*


------
https://chatgpt.com/codex/tasks/task_e_68b05fb9f6b88320a87130685171c718