### PR TITLE
feat: centralize Pexels API key configuration

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,5 @@
+export const PEXELS_API_KEY = process.env.PEXELS_API_KEY ?? '';
+
+if (!PEXELS_API_KEY) {
+  console.warn('PEXELS_API_KEY environment variable is not defined');
+}

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -5,13 +5,9 @@ import {useInfiniteQuery} from '@tanstack/react-query';
 import {getCollectionsMedia} from '../api/api';
 import ImageViewer from '../components/ImageViewer';
 import HeartWithLiquidActivityIndicator from '../components/HearthWithLiquidActivityIndicator';
+import {PEXELS_API_KEY} from '../config/env';
 
 const GalleryScreen: React.FC<GalleryScreenProps> = props => {
-  const PEXELS_API_KEY = process.env.PEXELS_API_KEY ?? '';
-  if (!PEXELS_API_KEY) {
-    console.warn('PEXELS_API_KEY environment variable is not defined');
-  }
-
   const {item} = props.route.params;
 
   const {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -18,6 +18,7 @@ import {
 } from '../types/types';
 import {useNavigation} from '@react-navigation/native';
 import HeartWithLiquidActivityIndicator from '../components/HearthWithLiquidActivityIndicator';
+import {PEXELS_API_KEY} from '../config/env';
 
 const ITEM_HEIGHT = 60;
 const SEPARATOR_HEIGHT = 12;
@@ -62,11 +63,6 @@ const ErrorMessage: React.FC<{onRetry: () => void}> = ({onRetry}) => (
 );
 
 const HomeScreen: React.FC = () => {
-  const PEXELS_API_KEY = process.env.PEXELS_API_KEY ?? '';
-  if (!PEXELS_API_KEY) {
-    console.warn('PEXELS_API_KEY environment variable is not defined');
-  }
-
   const {
     data,
     fetchNextPage,


### PR DESCRIPTION
## Summary
- add config module exposing `PEXELS_API_KEY` with single warning if missing
- use centralized API key in Home and Gallery screens

## Testing
- `yarn lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `yarn test` *(fails: project dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b05f611f0c8320976fd383bedb5969